### PR TITLE
Setup pipeline defined by `catalog-info`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ steps:
     branches: "*"
     command: |
       buildah --version
-      drivah build --changed-since=main ./.buildkite/containers/arm64
+      drivah build --changed-since=main ./containers/arm64
 
   # - label: ":buildah: Building Container Images for AMD64"
   #   branches: "*"

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode
+.idea
+
+workdir

--- a/containers/custom-nodejs-builder-amd64/Dockerfile
+++ b/containers/custom-nodejs-builder-amd64/Dockerfile
@@ -1,0 +1,31 @@
+FROM centos:7
+
+ARG GROUP_ID=1000
+ARG USER_ID=1000
+
+RUN groupadd --force --gid $GROUP_ID node
+RUN adduser --gid $GROUP_ID --uid $USER_ID node
+
+RUN ulimit -n 1024 \
+    && yum install -y epel-release \
+    && yum install -y centos-release-scl-rh \
+    && yum upgrade -y \
+    && yum install -y \
+         git \
+         curl \
+         make \
+         python2 \
+         python3 \
+         ccache \
+         xz-utils \
+         devtoolset-9 \
+         glibc-devel
+
+COPY --chown=node:node entrypoint.sh /home/node/entrypoint.sh
+COPY --chown=node:node re2_entrypoint.sh /home/node/re2_entrypoint.sh
+
+USER node
+
+VOLUME /home/node/workdir
+
+ENTRYPOINT [ "/home/node/entrypoint.sh" ]

--- a/containers/custom-nodejs-builder-amd64/drivah.toml
+++ b/containers/custom-nodejs-builder-amd64/drivah.toml
@@ -1,0 +1,13 @@
+[container.image]
+names = ["docker.elastic.co/ci-agent-images/kibana/custom-nodejs-builder"]
+tags = ["amd64-0.1"]
+
+[container.image.build_args]
+GROUP_ID = 1000
+USER_ID = 1000
+
+[docker]
+build_flags = [
+    "--progress=plain",
+    "--platform=linux/amd64"
+]

--- a/containers/custom-nodejs-builder-amd64/entrypoint.sh
+++ b/containers/custom-nodejs-builder-amd64/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+release_url_base="$1"
+full_version="$2"
+config_flags=${3:-""} #"--without-dtrace --without-npm --without-etw"
+
+if [[ $(arch) == x86_64 ]]; then
+  architecture="x64";
+else
+  architecture="arm64"
+fi
+
+cd "/home/node/workdir/src/node-${full_version}"
+
+# Compile from source
+export CCACHE_DIR="/home/node/workdir/.ccache-${architecture}"
+export CC="ccache gcc"
+export CXX="ccache g++"
+
+. /opt/rh/devtoolset-9/enable
+
+make -j"$(getconf _NPROCESSORS_ONLN)" binary V= \
+  DESTCPU="$architecture" \
+  ARCH="$architecture" \
+  VARIATION="glibc-217" \
+  DISTTYPE="release" \
+  RELEASE_URLBASE="$release_url_base" \
+  CONFIG_FLAGS="$config_flags"
+
+mkdir -p /home/node/workdir/dist/
+mv node-*.tar.?z /home/node/workdir/dist/

--- a/containers/custom-nodejs-builder-amd64/re2_entrypoint.sh
+++ b/containers/custom-nodejs-builder-amd64/re2_entrypoint.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+re2_full_version="$1"
+node_full_version="$2"
+node_download_base_url="$3"
+
+if [[ $(arch) == x86_64 ]]; then
+  architecture="x64";
+else
+  architecture="arm64"
+fi
+
+cd /home/node/workdir
+mkdir -p dist/
+mkdir -p src/
+
+## Download and unpack Node.js binary if needed.
+node_folder_name="node-${node_full_version}-linux-${architecture}"
+npm_binary="/home/node/workdir/${node_folder_name}/bin/npm"
+if [ ! -f "$npm_binary" ]; then
+    if [ ! -f "/home/node/workdir/$node_folder_name.tar.xz" ]; then
+        curl -fsSLO --compressed "${node_download_base_url}/${node_folder_name}.tar.xz"
+    fi
+
+    tar -xf "/home/node/workdir/${node_folder_name}.tar.xz"
+fi
+
+cd src
+
+## Download re2 source if needed.
+re2_source_folder="/home/node/workdir/src/node-re2-${re2_full_version}"
+if [ ! -d "$re2_source_folder" ]; then
+    git clone --recurse-submodules --depth 1 --branch 1.17.4 https://github.com/uhop/node-re2.git "${re2_source_folder}"
+fi
+
+cd "$re2_source_folder"
+export PATH="/home/node/workdir/${node_folder_name}/bin:$PATH"
+export DEVELOPMENT_SKIP_GETTING_ASSET=true
+
+export CCACHE_DIR="/home/node/workdir/.ccache-re2-${architecture}"
+export CC="ccache gcc"
+export CXX="ccache g++"
+
+. /opt/rh/devtoolset-9/enable
+
+npm i --unsafe-perm=true
+npm run build --if-present
+npm test
+
+mkdir -p /home/node/workdir/dist/
+cp "${re2_source_folder}/build/Release/re2.node" "/home/node/workdir/dist/linux-${architecture}-108"
+gzip -f "/home/node/workdir/dist/linux-${architecture}-108"

--- a/containers/custom-nodejs-builder-arm64/Dockerfile
+++ b/containers/custom-nodejs-builder-arm64/Dockerfile
@@ -1,0 +1,31 @@
+FROM centos:7
+
+ARG GROUP_ID=1000
+ARG USER_ID=1000
+
+RUN groupadd --force --gid $GROUP_ID node
+RUN adduser --gid $GROUP_ID --uid $USER_ID node
+
+RUN ulimit -n 1024 \
+    && yum install -y epel-release \
+    && yum install -y centos-release-scl-rh \
+    && yum upgrade -y \
+    && yum install -y \
+         git \
+         curl \
+         make \
+         python2 \
+         python3 \
+         ccache \
+         xz-utils \
+         devtoolset-9 \
+         glibc-devel
+
+COPY --chown=node:node entrypoint.sh /home/node/entrypoint.sh
+COPY --chown=node:node re2_entrypoint.sh /home/node/re2_entrypoint.sh
+
+USER node
+
+VOLUME /home/node/workdir
+
+ENTRYPOINT [ "/home/node/entrypoint.sh" ]

--- a/containers/custom-nodejs-builder-arm64/drivah.toml
+++ b/containers/custom-nodejs-builder-arm64/drivah.toml
@@ -1,0 +1,15 @@
+[container.image]
+names = ["docker.elastic.co/ci-agent-images/kibana/custom-nodejs-builder"]
+tags = ["arm64-0.1"]
+
+[container.image.build_args]
+GROUP_ID = 1000
+USER_ID = 1000
+
+[docker]
+build_flags = [
+    "--progress=plain",
+    "--platform=linux/arm64",
+    "--build-arg=\"GROUP_ID=1000\"",
+    "--build-arg=\"USER_ID=1000\""
+]

--- a/containers/custom-nodejs-builder-arm64/entrypoint.sh
+++ b/containers/custom-nodejs-builder-arm64/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+release_url_base="$1"
+full_version="$2"
+config_flags=${3:-""} #"--without-dtrace --without-npm --without-etw"
+
+if [[ $(arch) == x86_64 ]]; then
+  architecture="x64";
+else
+  architecture="arm64"
+fi
+
+cd "/home/node/workdir/src/node-${full_version}"
+
+# Compile from source
+export CCACHE_DIR="/home/node/workdir/.ccache-${architecture}"
+export CC="ccache gcc"
+export CXX="ccache g++"
+
+. /opt/rh/devtoolset-9/enable
+
+make -j"$(getconf _NPROCESSORS_ONLN)" binary V= \
+  DESTCPU="$architecture" \
+  ARCH="$architecture" \
+  VARIATION="glibc-217" \
+  DISTTYPE="release" \
+  RELEASE_URLBASE="$release_url_base" \
+  CONFIG_FLAGS="$config_flags"
+
+mkdir -p /home/node/workdir/dist/
+mv node-*.tar.?z /home/node/workdir/dist/

--- a/containers/custom-nodejs-builder-arm64/re2_entrypoint.sh
+++ b/containers/custom-nodejs-builder-arm64/re2_entrypoint.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+re2_full_version="$1"
+node_full_version="$2"
+node_download_base_url="$3"
+
+if [[ $(arch) == x86_64 ]]; then
+  architecture="x64";
+else
+  architecture="arm64"
+fi
+
+cd /home/node/workdir
+mkdir -p dist/
+mkdir -p src/
+
+## Download and unpack Node.js binary if needed.
+node_folder_name="node-${node_full_version}-linux-${architecture}"
+npm_binary="/home/node/workdir/${node_folder_name}/bin/npm"
+if [ ! -f "$npm_binary" ]; then
+    if [ ! -f "/home/node/workdir/$node_folder_name.tar.xz" ]; then
+        curl -fsSLO --compressed "${node_download_base_url}/${node_folder_name}.tar.xz"
+    fi
+
+    tar -xf "/home/node/workdir/${node_folder_name}.tar.xz"
+fi
+
+cd src
+
+## Download re2 source if needed.
+re2_source_folder="/home/node/workdir/src/node-re2-${re2_full_version}"
+if [ ! -d "$re2_source_folder" ]; then
+    git clone --recurse-submodules --depth 1 --branch 1.17.4 https://github.com/uhop/node-re2.git "${re2_source_folder}"
+fi
+
+cd "$re2_source_folder"
+export PATH="/home/node/workdir/${node_folder_name}/bin:$PATH"
+export DEVELOPMENT_SKIP_GETTING_ASSET=true
+
+export CCACHE_DIR="/home/node/workdir/.ccache-re2-${architecture}"
+export CC="ccache gcc"
+export CXX="ccache g++"
+
+. /opt/rh/devtoolset-9/enable
+
+npm i --unsafe-perm=true
+npm run build --if-present
+npm test
+
+mkdir -p /home/node/workdir/dist/
+cp "${re2_source_folder}/build/Release/re2.node" "/home/node/workdir/dist/linux-${architecture}-108"
+gzip -f "/home/node/workdir/dist/linux-${architecture}-108"


### PR DESCRIPTION
Adds: 
 - catalog-info.yaml to create a [pipeline](https://docs.elastic.dev/ci/getting-started-with-buildkite-at-elastic) (by ci-systems)
 - containers that contain `drivah` definitions for containers
 - buildkite pipeline def to run the `drivah` jobs