### PR TITLE
Fix re2 upload path

### DIFF
--- a/scripts/upload_re2_artifacts.sh
+++ b/scripts/upload_re2_artifacts.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 source ./scripts/common.sh
 
 RE2_FULL_VERSION=${RE2_VERSION:-1.17.7} # $1
-ARTIFACT_BASE_PATH="re2-glibc-217/v$RE2_FULL_VERSION/"
+ARTIFACT_BASE_PATH="re2-glibc-217/$RE2_FULL_VERSION/"
 ARTIFACT_DIST_DIR="./workdir_re2/dist"
 
 echo "--- Uploading build artifacts"


### PR DESCRIPTION
## What changed?
fix upload path of re2 resources to adhere to the paths of the original re2 download paths

We're proxying to paths like:
- `https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-re2/uhop/node-re2/releases/download/1.17.7/linux-x64-108.gz`

But we're uploading to paths like:
- `https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-re2/uhop/node-re2/releases/download/v1.17.7/linux-x64-108.gz`

