### PR TITLE
Update Node.js and re2 versions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 env:
-  TARGET_VERSION: 18.16.1
-  RE2_VERSION: 1.17.7
+  TARGET_VERSION: 18.17.0
+  RE2_VERSION: 1.20.1
 
 steps:
   - label: Annotate build with node version

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ You can run most scripts locally on Mac/Linux. You'll need a few of the build/in
 Export some env variables required for the builds
 ```sh
   export ARCH="arm64"
-  export TARGET_VERSION="18.16.1"
-  export RE2_VERSION="1.17.7"
+  export TARGET_VERSION="18.17.0"
+  export RE2_VERSION="1.20.1"
 ```
 
 Then run individual scripts locally:

--- a/scripts/build_re2.sh
+++ b/scripts/build_re2.sh
@@ -8,7 +8,7 @@ source ./scripts/common.sh
 assert_correct_arch $ARCH
 
 BUILD_IMAGE_NAME=$(get_build_image_name)
-RE2_FULL_VERSION=${RE2_VERSION:-1.17.7} # $1
+RE2_FULL_VERSION=${RE2_VERSION:-1.20.1} # $1
 NODE_FULL_VERSION="v$TARGET_VERSION" # $2
 NODE_DOWNLOAD_BASE_URL="https://storage.googleapis.com/$BUCKET_NAME/node-glibc-217/dist/v$TARGET_VERSION"
 TARGET_PLATFORM="linux/$ARCH"

--- a/scripts/build_re2.sh
+++ b/scripts/build_re2.sh
@@ -8,7 +8,7 @@ source ./scripts/common.sh
 assert_correct_arch $ARCH
 
 BUILD_IMAGE_NAME=$(get_build_image_name)
-RE2_FULL_VERSION=${RE2_VERSION:-1.20.1} # $1
+RE2_FULL_VERSION=$RE2_VERSION # $1
 NODE_FULL_VERSION="v$TARGET_VERSION" # $2
 NODE_DOWNLOAD_BASE_URL="https://storage.googleapis.com/$BUCKET_NAME/node-glibc-217/dist/v$TARGET_VERSION"
 TARGET_PLATFORM="linux/$ARCH"

--- a/scripts/upload_re2_artifacts.sh
+++ b/scripts/upload_re2_artifacts.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 source ./scripts/common.sh
 
-RE2_FULL_VERSION=${RE2_VERSION:-1.17.7} # $1
+RE2_FULL_VERSION=${RE2_VERSION:-1.20.1} # $1
 ARTIFACT_BASE_PATH="re2-glibc-217/$RE2_FULL_VERSION/"
 ARTIFACT_DIST_DIR="./workdir_re2/dist"
 

--- a/scripts/upload_re2_artifacts.sh
+++ b/scripts/upload_re2_artifacts.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 source ./scripts/common.sh
 
-RE2_FULL_VERSION=${RE2_VERSION:-1.20.1} # $1
+RE2_FULL_VERSION=$RE2_VERSION # $1
 ARTIFACT_BASE_PATH="re2-glibc-217/$RE2_FULL_VERSION/"
 ARTIFACT_DIST_DIR="./workdir_re2/dist"
 


### PR DESCRIPTION
~Depends on: elastic/kibana#162880~

Just housekeeping... we can always override these manually when building, but for now it's nice to have them up-to-date so they reflect reality