### PR TITLE
Update README.md, output hashes, and update catalog-info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@ Contains configuration and sources to build node.js
 
 The main usecase right now is building `node.js@18+` with `glibc@2.17`, which is required for some older platforms. (More context: https://github.com/nodejs/unofficial-builds/pull/69)
 
+## How to generate a new build? 
+We have a kibana-flavored buildkite job that does most of the work for building these distributables, by running the scripts in this repo. You can find the job here: https://buildkite.com/elastic/kibana-custom-node-dot-js-builds - [configured here](https://github.com/elastic/kibana-buildkite/blob/main/pipelines/kibana-custom-node-build.tf).
+
+### Build on a branch
+You can either create a new branch, where you set the new default values for the Node & re2 versions, and run a new build on that branch (or get the PR merged, and run a build on `main`). See [this PR](https://github.com/elastic/kibana-custom-nodejs-builds/pull/8) for reference.
+
+### Build with override parameters
+Or you can set override parameters on buildkite, when starting the job:
+```
+OVERRIDE_TARGET_VERSION=18.17.0
+OVERRIDE_RE2_VERSION=1.20.1
+```
+
 ## Running locally
 You can run most scripts locally on Mac/Linux. You'll need a few of the build/infra tools:
  - Docker

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You should see the job starting up two tasks in parallel. Those are the (node.js
 All the artifacts will be uploaded to this bucket: [kibana-custom-node-artifacts](https://console.cloud.google.com/storage/browser/kibana-custom-node-artifacts;tab=objects?forceOnBucketsSortingFiltering=true&project=elastic-kibana-184716&supportedpurview=project&prefix=&forceOnObjectsSortingFiltering=false&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22)))
 
 ### How to use these builds in Kibana?
-- First, follow the guide for upgrading node.js for Kibana: https://www.elastic.co/guide/en/kibana/8.9/upgrading-nodejs.html
+- First, follow the guide for upgrading node.js for Kibana: https://www.elastic.co/guide/en/kibana/current/upgrading-nodejs.html
 - Second, if you've updated RE2 versions, make sure to update the expected download hashes around in the [patch_native_modules_task.ts](https://github.com/elastic/kibana/blob/4c41247f938fcfde404a151a0b1193f3f5898cb1/src/dev/build/tasks/patch_native_modules_task.ts#L43)
 - Finally, keep in mind that your requests for downloading these resources will probably go through the [kibana-proxy-cache](https://github.com/elastic/kibana-ci-proxy-cache/), if you're reading this in 2026 you might need to update that code as well :)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All the artifacts will be uploaded to this bucket: [kibana-custom-node-artifacts
 
 ### How to use these builds in Kibana?
 - First, follow the guide for upgrading node.js for Kibana: https://www.elastic.co/guide/en/kibana/8.9/upgrading-nodejs.html
-- Second, if you've updated RE2 versions, make sure to update the expected download hashes around in the [patch_native_modules.tas.ts](https://github.com/elastic/kibana/blob/4c41247f938fcfde404a151a0b1193f3f5898cb1/src/dev/build/tasks/patch_native_modules_task.ts#L43)
+- Second, if you've updated RE2 versions, make sure to update the expected download hashes around in the [patch_native_modules_task.ts](https://github.com/elastic/kibana/blob/4c41247f938fcfde404a151a0b1193f3f5898cb1/src/dev/build/tasks/patch_native_modules_task.ts#L43)
 - Finally, keep in mind that your requests for downloading these resources will probably go through the [kibana-proxy-cache](https://github.com/elastic/kibana-ci-proxy-cache/), if you're reading this in 2026 you might need to update that code as well :)
 
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,31 @@
 # kibana-custom-nodejs-builds
 Contains configuration and sources to build node.js
 
-The main usecase right now is building `node.js@18+` with `glibc@2.17`, which is required for some older platforms. (More context: https://github.com/nodejs/unofficial-builds/pull/69)
+The main use case right now is building `node.js@18+` with `glibc@2.17`, which is required for some older platforms. (More context: https://github.com/nodejs/unofficial-builds/pull/69)
 
-## How to generate a new build? 
+## How to generate a new build?
 We have a kibana-flavored buildkite job that does most of the work for building these distributables, by running the scripts in this repo. You can find the job here: https://buildkite.com/elastic/kibana-custom-node-dot-js-builds - [configured here](https://github.com/elastic/kibana-buildkite/blob/main/pipelines/kibana-custom-node-build.tf).
 
 ### Build on a branch
 You can either create a new branch, where you set the new default values for the Node & re2 versions, and run a new build on that branch (or get the PR merged, and run a build on `main`). See [this PR](https://github.com/elastic/kibana-custom-nodejs-builds/pull/8) for reference.
 
 ### Build with override parameters
-Or you can set override parameters on buildkite, when starting the job:
+Or you can set override parameters on buildkite when starting the job:
 ```
 OVERRIDE_TARGET_VERSION=18.17.0
 OVERRIDE_RE2_VERSION=1.20.1
 ```
+
+### What happens after?
+You should see the job starting up two tasks in parallel. Those are the (node.js + re2) builds per platform. The arm64 cross-compilation takes a while, but once they're done, we also create a `SHASUMS256.txt` based on the original version's hashes, but updating the entries for our custom-built versions.
+
+All the artifacts will be uploaded to this bucket: [kibana-custom-node-artifacts](https://console.cloud.google.com/storage/browser/kibana-custom-node-artifacts;tab=objects?forceOnBucketsSortingFiltering=true&project=elastic-kibana-184716&supportedpurview=project&prefix=&forceOnObjectsSortingFiltering=false&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22)))
+
+### How to use these builds in Kibana?
+- First, follow the guide for upgrading node.js for Kibana: https://www.elastic.co/guide/en/kibana/8.9/upgrading-nodejs.html
+- Second, if you've updated RE2 versions, make sure to update the expected download hashes around in the [patch_native_modules.tas.ts](https://github.com/elastic/kibana/blob/4c41247f938fcfde404a151a0b1193f3f5898cb1/src/dev/build/tasks/patch_native_modules_task.ts#L43)
+- Finally, keep in mind that your requests for downloading these resources will probably go through the [kibana-proxy-cache](https://github.com/elastic/kibana-ci-proxy-cache/), if you're reading this in 2026 you might need to update that code as well :)
+
 
 ## Running locally
 You can run most scripts locally on Mac/Linux. You'll need a few of the build/infra tools:
@@ -24,16 +35,19 @@ You can run most scripts locally on Mac/Linux. You'll need a few of the build/in
 
 Export some env variables required for the builds
 ```sh
-  export ARCH="arm64"
+  export ARCH="arm64" # or amd64
   export TARGET_VERSION="18.17.0"
   export RE2_VERSION="1.20.1"
 ```
 
-Then run individual scripts locally:
+Then run any of the individual scripts locally:
 ```sh
   ./scripts/create_build_images.sh
   ./scripts/build_nodejs.sh
+  # ./scripts/...
 ```
+
+Keep in mind, individual steps might have a dependency on other steps. For reference, check the call order in [pipeline.yml](./.buildkite/pipeline.yml).
 
 ## Docker image for node.js builds
 One of the main components we need to create in this step is a docker image for an environment that's set up for building `node.js`.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,11 +1,12 @@
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-pipeline-kibana-custom-nodejs-builds
+  name: kibana-custom-node-dot-js-builds
   description: Buildkite Pipeline for kibana-custom-nodejs-builds
-  owner: group:kibana-operations
   links:
     - title: Pipeline
-      url: https://buildkite.com/elastic/kibana-custom-nodejs-builds
+      url: https://buildkite.com/elastic/kibana-custom-node-dot-js-builds
+spec:
+  owner: group:kibana-operations
+  type: tool

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,6 +5,7 @@ kind: Resource
 metadata:
   name: buildkite-pipeline-kibana-custom-nodejs-builds
   description: Buildkite Pipeline for kibana-custom-nodejs-builds
+  owner: group:kibana-operations
   links:
     - title: Pipeline
       url: https://buildkite.com/elastic/kibana-custom-nodejs-builds

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -73,3 +73,13 @@ function replace_shasums_in_folder() {
 
   cd -
 }
+
+function list_shasums_in_folder() {
+  local dirname=$1
+
+  echo --- Sha256 checksums for files in $dirname
+  for file in $(ls $dirname); do
+    local full_filename="$dirname/$file"
+    shasum -a 256 $full_filename
+  done
+}

--- a/scripts/upload_nodejs_artifacts.sh
+++ b/scripts/upload_nodejs_artifacts.sh
@@ -8,5 +8,7 @@ source ./scripts/common.sh
 ARTIFACT_BASE_PATH="node-glibc-217/dist/v$TARGET_VERSION/"
 ARTIFACT_DIST_DIR="./workdir/dist"
 
+list_shasums_in_folder $ARTIFACT_DIST_DIR
+
 echo "--- Uploading build artifacts"
 gsutil cp -r "$ARTIFACT_DIST_DIR/*" gs://$BUCKET_NAME/$ARTIFACT_BASE_PATH

--- a/scripts/upload_re2_artifacts.sh
+++ b/scripts/upload_re2_artifacts.sh
@@ -7,5 +7,7 @@ RE2_FULL_VERSION=$RE2_VERSION # $1
 ARTIFACT_BASE_PATH="re2-glibc-217/$RE2_FULL_VERSION/"
 ARTIFACT_DIST_DIR="./workdir_re2/dist"
 
+list_shasums_in_folder $ARTIFACT_DIST_DIR
+
 echo "--- Uploading build artifacts"
 gsutil cp -r "$ARTIFACT_DIST_DIR/*" gs://$BUCKET_NAME/$ARTIFACT_BASE_PATH


### PR DESCRIPTION
- Adds some help on how to generate new versions using the buildkite job backed by this repo.
- Adds some explanation on what happens with the built resources
- Updates `catalog-info.yaml` to reflect ownership
- Output sha256 hashes of built resources before uploading