### PR TITLE
[BK] Rename ARCH -> TARGET_ARCH

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
       - scripts/build_re2.sh
       - scripts/upload_re2_artifacts.sh
     env:
-      ARCH: amd64
+      TARGET_ARCH: amd64
     agents:
       image: family/kibana-ubuntu-2004
       imageProject: elastic-images-qa
@@ -31,7 +31,7 @@ steps:
       - scripts/build_re2.sh
       - scripts/upload_re2_artifacts.sh
     env:
-      ARCH: arm64
+      TARGET_ARCH: arm64
     agents:
       image: family/kibana-ubuntu-2004
       imageProject: elastic-images-qa

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can run most scripts locally on Mac/Linux. You'll need a few of the build/in
 
 Export some env variables required for the builds
 ```sh
-  export ARCH="arm64" # or amd64
+  export TARGET_ARCH="arm64" # or amd64
   export TARGET_VERSION="18.17.0"
   export RE2_VERSION="1.20.1"
 ```

--- a/scripts/build_nodejs.sh
+++ b/scripts/build_nodejs.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 source ./scripts/common.sh
 
 # TARGET_VERSION provided in env
-# ARCH provided in env
-assert_correct_arch $ARCH
+# TARGET_ARCH provided in env
+assert_correct_arch $TARGET_ARCH
 
 TARGET_NODE_VERSION="v$TARGET_VERSION"
 BUILD_IMAGE_NAME=$(get_build_image_name)
-TARGET_PLATFORM="linux/$ARCH"
+TARGET_PLATFORM="linux/$TARGET_ARCH"
 RELEASE_URL_BASE="https://unofficial-builds.nodejs.org/download/release/"
 
 echo "Running node.js build in folder: `pwd`"

--- a/scripts/build_re2.sh
+++ b/scripts/build_re2.sh
@@ -4,14 +4,14 @@ set -euo pipefail
 source ./scripts/common.sh
 
 # TARGET_VERSION provided in env
-# ARCH provided in env
-assert_correct_arch $ARCH
+# TARGET_ARCH provided in env
+assert_correct_arch $TARGET_ARCH
 
 BUILD_IMAGE_NAME=$(get_build_image_name)
 RE2_FULL_VERSION=$RE2_VERSION # $1
 NODE_FULL_VERSION="v$TARGET_VERSION" # $2
 NODE_DOWNLOAD_BASE_URL="https://storage.googleapis.com/$BUCKET_NAME/node-glibc-217/dist/v$TARGET_VERSION"
-TARGET_PLATFORM="linux/$ARCH"
+TARGET_PLATFORM="linux/$TARGET_ARCH"
 
 echo "--- Building RE2 for $TARGET_PLATFORM"
 mkdir -p ./workdir_re2/

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -5,20 +5,20 @@ export TARGET_VERSION=${OVERRIDE_TARGET_VERSION:-$TARGET_VERSION}
 export RE2_VERSION=${OVERRIDE_RE2_VERSION:-$RE2_VERSION}
 
 function assert_correct_arch() {
-  ARCH=$1
+  TARGET_ARCH=$1
 
-  if [[ "$ARCH" == "arm64" || "$ARCH" == "amd64" ]]; then
+  if [[ "$TARGET_ARCH" == "arm64" || "$TARGET_ARCH" == "amd64" ]]; then
     # we're good, supported architecture
-    echo "Building for architecture: $ARCH"
+    echo "Building for architecture: $TARGET_ARCH"
   else
-    echo "ARCH (=$ARCH) env variable is not one of: arm64, amd64"
+    echo "TARGET_ARCH (=$TARGET_ARCH) env variable is not one of: arm64, amd64"
     exit 1
   fi
 }
 
 function get_build_image_name() {
   NODE_VERSION=${1:-$TARGET_VERSION}
-  PLATFORM=${2:-$ARCH}
+  PLATFORM=${2:-$TARGET_ARCH}
 
   echo "docker.elastic.co/elastic/nodejs-custom:$NODE_VERSION-$PLATFORM"
 }

--- a/scripts/create_build_images.sh
+++ b/scripts/create_build_images.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 source ./scripts/common.sh
 
 # TARGET_VERSION provided in env
-# ARCH provided in env
-assert_correct_arch $ARCH
+# TARGET_ARCH provided in env
+assert_correct_arch $TARGET_ARCH
 
-TARGET_PLATFORM="linux/$ARCH"
+TARGET_PLATFORM="linux/$TARGET_ARCH"
 IMAGE_NAME=$(get_build_image_name)
 SCRIPT_DIR=$(dirname $0)
 DOCKER_BUILD_CONTEXT_DIR="$SCRIPT_DIR/../build-image-config/"
@@ -19,7 +19,7 @@ if [[ $(docker buildx ls | grep multiarch | wc -l) -lt 1 ]]; then
 fi
 
 
-echo "--- Building node.js build image ($ARCH)"
+echo "--- Building node.js build image ($TARGET_ARCH)"
 DOCKER_BUILDKIT=1 docker buildx build --progress=plain  \
   --platform $TARGET_PLATFORM \
   --build-arg GROUP_ID=1000 --build-arg USER_ID=1000 \


### PR DESCRIPTION
$ARCH seems to always evaluate to x86_64, despite the correct env declarations in the job; maybe it's used by the agent's image

See: https://buildkite.com/elastic/kibana-custom-node-dot-js-builds/builds/142