### PR TITLE
[FIX] extract service account key early, to avoid expiry of vault token

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -85,8 +85,7 @@ function list_shasums_in_folder() {
 }
 
 # Activates buildkite-agent service account to be able to upload artifacts to GCS
+GCS_SA_KEY=$(vault read -field=key secret/ci/elastic-kibana-custom-nodejs-builds/custom-node-artifacts-service-account-key | base64 -d)
 function activate_service_account() {
-  KEY=$(vault read -field=key secret/ci/elastic-kibana-custom-nodejs-builds/custom-node-artifacts-service-account-key | base64 -d)
-
-  gcloud auth activate-service-account --key-file <(echo $KEY)
+  gcloud auth activate-service-account --key-file <(echo $GCS_SA_KEY)
 }


### PR DESCRIPTION
There seems to be an unexpected case where the service-account-key cannot be accessed because vault responds with 403. 

This PR tries to get the key earlier, in case the reason was an expiring token.

Attempt 2: https://buildkite.com/elastic/kibana-custom-node-dot-js-builds/builds/158#018f7729-4b71-4786-af90-d4fda62ba4f8