### PR TITLE
Update glibc-217 base image to use available base url

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,9 +11,9 @@ steps:
     command:
       - scripts/create_build_images.sh
       - scripts/build_nodejs.sh
-      # - scripts/upload_nodejs_artifacts.sh
+      - scripts/upload_nodejs_artifacts.sh
       - scripts/build_re2.sh
-      # - scripts/upload_re2_artifacts.sh
+      - scripts/upload_re2_artifacts.sh
     env:
       TARGET_ARCH: amd64
       TARGET_VARIANT: 'glibc-217'
@@ -27,9 +27,9 @@ steps:
     command:
       - scripts/create_build_images.sh
       - scripts/build_nodejs.sh
-      # - scripts/upload_nodejs_artifacts.sh
+      - scripts/upload_nodejs_artifacts.sh
       - scripts/build_re2.sh
-      # - scripts/upload_re2_artifacts.sh
+      - scripts/upload_re2_artifacts.sh
     env:
       TARGET_ARCH: arm64
       TARGET_VARIANT: 'glibc-217'
@@ -44,7 +44,7 @@ steps:
     command:
       - scripts/create_build_images.sh
       - scripts/build_nodejs.sh
-      # - scripts/upload_nodejs_artifacts.sh
+      - scripts/upload_nodejs_artifacts.sh
     env:
       TARGET_ARCH: amd64
       TARGET_VARIANT: 'pointer-compression'
@@ -58,7 +58,7 @@ steps:
     command:
       - scripts/create_build_images.sh
       - scripts/build_nodejs.sh
-      # - scripts/upload_nodejs_artifacts.sh
+      - scripts/upload_nodejs_artifacts.sh
     env:
       TARGET_ARCH: arm64
       TARGET_VARIANT: 'pointer-compression'
@@ -68,24 +68,24 @@ steps:
       machineType: c2-standard-60
     timeout_in_minutes: 180 # ideally runs in ~2hr
 
-  # - wait
+  - wait
 
-  # - label: Fix SHASUMS256.txt with newly built files' hashes with glibc 2.17
-  #   command:
-  #     - scripts/replace_sha_hashes.sh
-  #   env:
-  #     TARGET_VARIANT: 'glibc-217'
-  #   agents:
-  #     image: family/kibana-ubuntu-2004
-  #     provider: gcp
-  #     machineType: n2-standard-2
+  - label: Fix SHASUMS256.txt with newly built files' hashes with glibc 2.17
+    command:
+      - scripts/replace_sha_hashes.sh
+    env:
+      TARGET_VARIANT: 'glibc-217'
+    agents:
+      image: family/kibana-ubuntu-2004
+      provider: gcp
+      machineType: n2-standard-2
 
-  # - label: Fix SHASUMS256.txt with newly built files' hashes with pointer compression
-  #   command:
-  #     - scripts/replace_sha_hashes.sh
-  #   env:
-  #     TARGET_VARIANT: 'pointer-compression'
-  #   agents:
-  #     image: family/kibana-ubuntu-2004
-  #     provider: gcp
-  #     machineType: n2-standard-2
+  - label: Fix SHASUMS256.txt with newly built files' hashes with pointer compression
+    command:
+      - scripts/replace_sha_hashes.sh
+    env:
+      TARGET_VARIANT: 'pointer-compression'
+    agents:
+      image: family/kibana-ubuntu-2004
+      provider: gcp
+      machineType: n2-standard-2

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,9 +11,9 @@ steps:
     command:
       - scripts/create_build_images.sh
       - scripts/build_nodejs.sh
-      - scripts/upload_nodejs_artifacts.sh
+      # - scripts/upload_nodejs_artifacts.sh
       - scripts/build_re2.sh
-      - scripts/upload_re2_artifacts.sh
+      # - scripts/upload_re2_artifacts.sh
     env:
       TARGET_ARCH: amd64
       TARGET_VARIANT: 'glibc-217'
@@ -27,9 +27,9 @@ steps:
     command:
       - scripts/create_build_images.sh
       - scripts/build_nodejs.sh
-      - scripts/upload_nodejs_artifacts.sh
+      # - scripts/upload_nodejs_artifacts.sh
       - scripts/build_re2.sh
-      - scripts/upload_re2_artifacts.sh
+      # - scripts/upload_re2_artifacts.sh
     env:
       TARGET_ARCH: arm64
       TARGET_VARIANT: 'glibc-217'
@@ -44,7 +44,7 @@ steps:
     command:
       - scripts/create_build_images.sh
       - scripts/build_nodejs.sh
-      - scripts/upload_nodejs_artifacts.sh
+      # - scripts/upload_nodejs_artifacts.sh
     env:
       TARGET_ARCH: amd64
       TARGET_VARIANT: 'pointer-compression'
@@ -58,7 +58,7 @@ steps:
     command:
       - scripts/create_build_images.sh
       - scripts/build_nodejs.sh
-      - scripts/upload_nodejs_artifacts.sh
+      # - scripts/upload_nodejs_artifacts.sh
     env:
       TARGET_ARCH: arm64
       TARGET_VARIANT: 'pointer-compression'
@@ -68,24 +68,24 @@ steps:
       machineType: c2-standard-60
     timeout_in_minutes: 180 # ideally runs in ~2hr
 
-  - wait
+  # - wait
 
-  - label: Fix SHASUMS256.txt with newly built files' hashes with glibc 2.17
-    command:
-      - scripts/replace_sha_hashes.sh
-    env:
-      TARGET_VARIANT: 'glibc-217'
-    agents:
-      image: family/kibana-ubuntu-2004
-      provider: gcp
-      machineType: n2-standard-2
+  # - label: Fix SHASUMS256.txt with newly built files' hashes with glibc 2.17
+  #   command:
+  #     - scripts/replace_sha_hashes.sh
+  #   env:
+  #     TARGET_VARIANT: 'glibc-217'
+  #   agents:
+  #     image: family/kibana-ubuntu-2004
+  #     provider: gcp
+  #     machineType: n2-standard-2
 
-  - label: Fix SHASUMS256.txt with newly built files' hashes with pointer compression
-    command:
-      - scripts/replace_sha_hashes.sh
-    env:
-      TARGET_VARIANT: 'pointer-compression'
-    agents:
-      image: family/kibana-ubuntu-2004
-      provider: gcp
-      machineType: n2-standard-2
+  # - label: Fix SHASUMS256.txt with newly built files' hashes with pointer compression
+  #   command:
+  #     - scripts/replace_sha_hashes.sh
+  #   env:
+  #     TARGET_VARIANT: 'pointer-compression'
+  #   agents:
+  #     image: family/kibana-ubuntu-2004
+  #     provider: gcp
+  #     machineType: n2-standard-2

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -9,7 +9,7 @@ ARG USER_ID=1000
 RUN groupadd --force --gid $GROUP_ID node
 RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
-RUN ulimit -n 1024 \
+RUN ulimit -n 1024 && \
     rpm --import https://repo.cloudlinux.com/cloudlinux/security/RPM-GPG-KEY-CloudLinux && \
     yum-config-manager --add-repo https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/x86_64/ && \
     yum install -y epel-release  && \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -8,11 +8,7 @@ RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
 RUN ulimit -n 1024 \
     && sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-* \
-    && if [ "$(uname -m)" == "x86_64" ]; then \
-      sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*; \
-    else \
-      sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org/altarch|g' /etc/yum.repos.d/CentOS-*; \
-    fi \
+    && sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     && yum install -y epel-release \
     && yum install -y centos-release-scl-rh \
     && sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
-RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* && \
-    sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \
+    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
 
 ARG GROUP_ID=1000
 ARG USER_ID=1000
@@ -9,12 +9,11 @@ ARG USER_ID=1000
 RUN groupadd --force --gid $GROUP_ID node
 RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
-RUN ulimit -n 1024 && \
-    rpm --import https://repo.cloudlinux.com/cloudlinux/security/RPM-GPG-KEY-CloudLinux && \
-    yum-config-manager --add-repo https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/x86_64/ && \
-    yum install -y epel-release  && \
-    yum upgrade -y && \
-    yum install -y \
+RUN ulimit -n 1024 \
+    && yum install -y epel-release  \
+    && yum install -y centos-release-scl-rh \
+    && yum upgrade -y \
+    && yum install -y \
         git \
         curl \
         make \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,17 +1,16 @@
 FROM centos:7
 
-RUN echo "[centos-sclo-rh]" > /etc/yum.repos.d/centos-release-scl-rh.repo \
-    && echo "name=CentOS-7 - SCLo rh" >> /etc/yum.repos.d/centos-release-scl-rh.repo \
-    && echo "baseurl=http://vault.centos.org/centos/7/sclo/\$basearch/rh/" >> /etc/yum.repos.d/centos-release-scl-rh.repo \
-    && echo "gpgcheck=1" >> /etc/yum.repos.d/centos-release-scl-rh.repo \
-    && echo "enabled=1" >> /etc/yum.repos.d/centos-release-scl-rh.repo \
-    && echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo" >> /etc/yum.repos.d/centos-release-scl-rh.repo
-
-RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \
-    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-*
+RUN if [ "$(uname -m)" == "x86_64" ]; then \
+      echo "Running on x64 architecture"; \
+      sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo; \
+    else \
+      echo "Running on non-x64 architecture"; \
+      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \
+    fi
+RUN sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
 
 RUN cat /etc/yum.repos.d/*.repo
-RUN cat /etc/yum.repos.d/centos-release-scl-rh.repo
 
 ARG GROUP_ID=1000
 ARG USER_ID=1000
@@ -20,6 +19,7 @@ RUN groupadd --force --gid $GROUP_ID node
 RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
 RUN ulimit -n 1024 \
+    && yum update -y \
     && yum clean all \
     && yum install -y epel-release  \
     && yum install -y centos-release-scl-rh \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -12,10 +12,8 @@ RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
 RUN ulimit -n 1024 \
     && yum install -y epel-release  \
-    && yum install -y centos-release-scl \
-    && yum-config-manager --enable centos-sclo-rh \
-    && yum -y update --setopt=skip_if_unavailable=true \
-    && yum clean all \
+    && yum install -y centos-release-scl-rh \
+    && yum upgrade -y \
     && yum install -y \
         git \
         curl \
@@ -26,8 +24,6 @@ RUN ulimit -n 1024 \
         xz-utils \
         devtoolset-9 \
         glibc-devel
-
-RUN scl enable devtoolset-9 bash
 
 COPY --chown=node:node entrypoint.sh /home/node/entrypoint.sh
 COPY --chown=node:node re2_entrypoint.sh /home/node/re2_entrypoint.sh

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -11,11 +11,11 @@ RUN groupadd --force --gid $GROUP_ID node
 RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
 RUN ulimit -n 1024 \
-    && yum update -y \
-    && yum clean all \
     && yum install -y epel-release  \
-    && yum install -y centos-release-scl-rh \
-    && yum upgrade -y \
+    && yum install -y centos-release-scl \
+    && yum-config-manager --enable centos-sclo-rh \
+    && yum -y update --setopt=skip_if_unavailable=true \
+    && yum clean all \
     && yum install -y \
         git \
         curl \
@@ -26,6 +26,8 @@ RUN ulimit -n 1024 \
         xz-utils \
         devtoolset-9 \
         glibc-devel
+
+RUN scl enable devtoolset-9 bash
 
 COPY --chown=node:node entrypoint.sh /home/node/entrypoint.sh
 COPY --chown=node:node re2_entrypoint.sh /home/node/re2_entrypoint.sh

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,8 +1,8 @@
 FROM centos:7
 
-RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \
-    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-* \
-    && sed -i -e "s|mirror.centos.org|vault.centos.org|g" /etc/yum.repos.d/CentOS-*
+RUN sed -i -e "s|mirror.centos.org|vault.centos.org|g" /etc/yum.repos.d/*.repo \ 
+    && sed -i -e "s|^#.*baseurl=|baseurl=|g" /etc/yum.repos.d/*.repo \
+    && sed -i -e "s|^mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/*.repo
 
 ARG GROUP_ID=1000
 ARG USER_ID=1000

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -19,15 +19,15 @@ RUN ulimit -n 1024 \
     fi \
     && yum upgrade -y \
     && yum install -y \
-        git \
-        curl \
-        make \
-        python2 \
-        python3 \
-        ccache \
-        xz \
-        devtoolset-9 \
-        glibc-devel
+         git \
+         curl \
+         make \
+         python2 \
+         python3 \
+         ccache \
+         xz-utils \
+         devtoolset-9 \
+         glibc-devel
 
 COPY --chown=node:node entrypoint.sh /home/node/entrypoint.sh
 COPY --chown=node:node re2_entrypoint.sh /home/node/re2_entrypoint.sh

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -4,6 +4,7 @@ RUN echo "[centos-sclo-rh]" > /etc/yum.repos.d/centos-release-scl-rh.repo \
     && echo "name=CentOS-7 - SCLo rh" >> /etc/yum.repos.d/centos-release-scl-rh.repo \
     && echo "baseurl=http://vault.centos.org/centos/7/sclo/\$basearch/rh/" >> /etc/yum.repos.d/centos-release-scl-rh.repo \
     && echo "gpgcheck=1" >> /etc/yum.repos.d/centos-release-scl-rh.repo \
+    && echo "enabled=1" >> /etc/yum.repos.d/centos-release-scl-rh.repo \
     && echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo" >> /etc/yum.repos.d/centos-release-scl-rh.repo
 
 RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -14,7 +14,7 @@ RUN ulimit -n 1024 && \
     yum-config-manager --add-repo https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/x86_64/ && \
     yum install -y epel-release  && \
     yum upgrade -y && \
-    yum install -y && \
+    yum install -y \
         git \
         curl \
         make \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,8 +1,13 @@
 FROM centos:7
 
-RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
-    && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
-    && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+RUN echo "[centos-sclo-rh]" > /etc/yum.repos.d/centos-release-scl-rh.repo \
+    && echo "name=CentOS-7 - SCLo rh" >> /etc/yum.repos.d/centos-release-scl-rh.repo \
+    && echo "baseurl=http://vault.centos.org/centos/7/sclo/\$basearch/rh/" >> /etc/yum.repos.d/centos-release-scl-rh.repo \
+    && echo "gpgcheck=1" >> /etc/yum.repos.d/centos-release-scl-rh.repo \
+    && echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo" >> /etc/yum.repos.d/centos-release-scl-rh.repo
+
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \
+    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
 
 RUN cat /etc/yum.repos.d/*.repo
 RUN cat /etc/yum.repos.d/centos-release-scl-rh.repo

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,10 +1,5 @@
 FROM centos:7
 
-RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo \
-    && sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Base.repo
-    
-RUN cat /etc/yum.repos.d/*.repo
-
 ARG GROUP_ID=1000
 ARG USER_ID=1000
 
@@ -12,23 +7,21 @@ RUN groupadd --force --gid $GROUP_ID node
 RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
 RUN ulimit -n 1024 \
-    && yum update -y \
-    && yum clean all \
-    && yum install -y epel-release  \
-    && yum install -y centos-release-scl-rh
-
-RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-RUN if [ "$(uname -m)" == "x86_64" ]; then \
-      echo "Running on x64 architecture"; \
+    && sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-* \
+    && if [ "$(uname -m)" == "x86_64" ]; then \
+      sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*; \
+    else \
+      sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org/altarch|g' /etc/yum.repos.d/CentOS-*; \
+    fi \
+    && yum install -y epel-release \
+    && yum install -y centos-release-scl-rh \
+    && sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
+    && if [ "$(uname -m)" == "x86_64" ]; then \
       sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
     else \
-      echo "Running on non-x64 architecture"; \
       sed -i -e 's|#baseurl=http://mirror.centos.org/centos|baseurl=http://vault.centos.org/altarch|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
-    fi
-
-RUN cat /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-    
-RUN yum upgrade -y \
+    fi \
+    && yum upgrade -y \
     && yum install -y \
         git \
         curl \
@@ -36,7 +29,7 @@ RUN yum upgrade -y \
         python2 \
         python3 \
         ccache \
-        xz-utils \
+        xz \
         devtoolset-9 \
         glibc-devel
 

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -4,6 +4,8 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
+RUN cat /etc/yum.repos.d/*.repo
+
 ARG GROUP_ID=1000
 ARG USER_ID=1000
 
@@ -11,6 +13,7 @@ RUN groupadd --force --gid $GROUP_ID node
 RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
 RUN ulimit -n 1024 \
+    && yum clean metadata \
     && yum install -y epel-release  \
     && yum install -y centos-release-scl-rh \
     && yum upgrade -y \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-*
+RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo
 RUN if [ "$(uname -m)" == "x86_64" ]; then \
       echo "Running on x64 architecture"; \
       sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo; \
@@ -8,8 +8,7 @@ RUN if [ "$(uname -m)" == "x86_64" ]; then \
       echo "Running on non-x64 architecture"; \
       sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \
     fi
-RUN sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
-
+    
 RUN cat /etc/yum.repos.d/*.repo
 
 ARG GROUP_ID=1000
@@ -22,8 +21,20 @@ RUN ulimit -n 1024 \
     && yum update -y \
     && yum clean all \
     && yum install -y epel-release  \
-    && yum install -y centos-release-scl-rh \
-    && yum upgrade -y \
+    && yum install -y centos-release-scl-rh
+
+RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+RUN if [ "$(uname -m)" == "x86_64" ]; then \
+      echo "Running on x64 architecture"; \
+      sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+    else \
+      echo "Running on non-x64 architecture"; \
+      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+    fi
+
+RUN cat /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+    
+RUN yum upgrade -y \
     && yum install -y \
         git \
         curl \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,13 +1,7 @@
 FROM centos:7
 
-RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo
-RUN if [ "$(uname -m)" == "x86_64" ]; then \
-      echo "Running on x64 architecture"; \
-      sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo; \
-    else \
-      echo "Running on non-x64 architecture"; \
-      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \
-    fi
+RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo \
+    && sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Base.repo
     
 RUN cat /etc/yum.repos.d/*.repo
 
@@ -26,10 +20,10 @@ RUN ulimit -n 1024 \
 RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
 RUN if [ "$(uname -m)" == "x86_64" ]; then \
       echo "Running on x64 architecture"; \
-      sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+      sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
     else \
       echo "Running on non-x64 architecture"; \
-      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+      sed -i -e 's|#baseurl=http://mirror.centos.org/centos|baseurl=http://vault.centos.org/altarch|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
     fi
 
 RUN cat /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,7 +1,8 @@
 FROM centos:7
 
 RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \
-    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
+    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-* \
+    && sed -i -e "s|mirror.centos.org|vault.centos.org|g" /etc/yum.repos.d/CentOS-*
 
 ARG GROUP_ID=1000
 ARG USER_ID=1000

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,9 +1,7 @@
 FROM centos:7
 
-RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \
-    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
-
-COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* && \
+    sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
 
 ARG GROUP_ID=1000
 ARG USER_ID=1000
@@ -12,18 +10,21 @@ RUN groupadd --force --gid $GROUP_ID node
 RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
 RUN ulimit -n 1024 \
-    && yum install -y epel-release \
-    && yum upgrade -y \
-    && yum install -y \
-         git \
-         curl \
-         make \
-         python2 \
-         python3 \
-         ccache \
-         xz-utils \
-         devtoolset-9 \
-         glibc-devel
+    yum install -y yum-utils && \
+    rpm --import https://repo.cloudlinux.com/cloudlinux/security/RPM-GPG-KEY-CloudLinux && \
+    yum-config-manager --add-repo https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/x86_64/ && \
+    yum install -y epel-release  && \
+    yum upgrade -y && \
+    yum install -y && \
+        git \
+        curl \
+        make \
+        python2 \
+        python3 \
+        ccache \
+        xz-utils \
+        devtoolset-9 \
+        glibc-devel
 
 COPY --chown=node:node entrypoint.sh /home/node/entrypoint.sh
 COPY --chown=node:node re2_entrypoint.sh /home/node/re2_entrypoint.sh

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -10,7 +10,6 @@ RUN groupadd --force --gid $GROUP_ID node
 RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
 RUN ulimit -n 1024 \
-    yum install -y yum-utils && \
     rpm --import https://repo.cloudlinux.com/cloudlinux/security/RPM-GPG-KEY-CloudLinux && \
     yum-config-manager --add-repo https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/x86_64/ && \
     yum install -y epel-release  && \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -11,6 +11,8 @@ RUN groupadd --force --gid $GROUP_ID node
 RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
 RUN ulimit -n 1024 \
+    && yum update -y \
+    && yum clean all \
     && yum install -y epel-release  \
     && yum install -y centos-release-scl-rh \
     && yum upgrade -y \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -5,6 +5,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
 RUN cat /etc/yum.repos.d/*.repo
+RUN cat /etc/yum.repos.d/centos-release-scl-rh.repo
 
 ARG GROUP_ID=1000
 ARG USER_ID=1000
@@ -13,7 +14,7 @@ RUN groupadd --force --gid $GROUP_ID node
 RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
 RUN ulimit -n 1024 \
-    && yum clean metadata \
+    && yum clean all \
     && yum install -y epel-release  \
     && yum install -y centos-release-scl-rh \
     && yum upgrade -y \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,8 +1,8 @@
 FROM centos:7
 
-RUN sed -i -e "s|mirror.centos.org|vault.centos.org|g" /etc/yum.repos.d/*.repo \ 
-    && sed -i -e "s|^#.*baseurl=|baseurl=|g" /etc/yum.repos.d/*.repo \
-    && sed -i -e "s|^mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/*.repo
+RUN sed -i -e "s|mirror.centos.org|vault.centos.org|g" /etc/yum.repos.d/*.repo \
+    && sed -i -e "s|^mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/*.repo \
+    && sed -i -e "s|^#baseurl=|baseurl=|g" /etc/yum.repos.d/*.repo
 
 ARG GROUP_ID=1000
 ARG USER_ID=1000

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,5 +1,10 @@
 FROM centos:7
 
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \
+    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
+
+COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
+
 ARG GROUP_ID=1000
 ARG USER_ID=1000
 
@@ -8,7 +13,6 @@ RUN adduser --gid $GROUP_ID --uid $USER_ID node
 
 RUN ulimit -n 1024 \
     && yum install -y epel-release \
-    && yum install -y centos-release-scl-rh \
     && yum upgrade -y \
     && yum install -y \
          git \

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -1,8 +1,8 @@
 FROM centos:7
 
-RUN sed -i -e "s|mirror.centos.org|vault.centos.org|g" /etc/yum.repos.d/*.repo \
-    && sed -i -e "s|^mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/*.repo \
-    && sed -i -e "s|^#baseurl=|baseurl=|g" /etc/yum.repos.d/*.repo
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
+    && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
+    && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
 ARG GROUP_ID=1000
 ARG USER_ID=1000


### PR DESCRIPTION
CentOS 7 is EOL.  Instead of using mirrorlist, this updates the base
image to use vault.