### PR TITLE
Fix glibc-217 builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,33 +35,35 @@ steps:
       machineType: c2-standard-60
     timeout_in_minutes: 180 # ideally runs in ~2hr
 
-  - label: Build custom node.js artifacts with pointer compression for x64
-    command:
-      - scripts/create_build_images.sh
-      - scripts/build_nodejs.sh
-      - scripts/upload_nodejs_artifacts.sh
-    env:
-      TARGET_ARCH: amd64
-      TARGET_VARIANT: 'pointer-compression'
-    agents:
-      image: family/kibana-ubuntu-2004
-      provider: gcp
-      machineType: c2-standard-16
-    timeout_in_minutes: 60 # ideally runs in ~30m
+  # See https://github.com/nodejs/node/issues/54531
+  # - label: Build custom node.js artifacts with pointer compression for x64
+  #   command:
+  #     - scripts/create_build_images.sh
+  #     - scripts/build_nodejs.sh
+  #     - scripts/upload_nodejs_artifacts.sh
+  #   env:
+  #     TARGET_ARCH: amd64
+  #     TARGET_VARIANT: 'pointer-compression'
+  #   agents:
+  #     image: family/kibana-ubuntu-2004
+  #     provider: gcp
+  #     machineType: c2-standard-16
+  #   timeout_in_minutes: 60 # ideally runs in ~30m
 
-  - label: Build custom node.js artifacts with pointer compression for arm64
-    command:
-      - scripts/create_build_images.sh
-      - scripts/build_nodejs.sh
-      - scripts/upload_nodejs_artifacts.sh
-    env:
-      TARGET_ARCH: arm64
-      TARGET_VARIANT: 'pointer-compression'
-    agents:
-      image: family/kibana-ubuntu-2004
-      provider: gcp
-      machineType: c2-standard-60
-    timeout_in_minutes: 180 # ideally runs in ~2hr
+  # See https://github.com/nodejs/node/issues/54531
+  # - label: Build custom node.js artifacts with pointer compression for arm64
+  #   command:
+  #     - scripts/create_build_images.sh
+  #     - scripts/build_nodejs.sh
+  #     - scripts/upload_nodejs_artifacts.sh
+  #   env:
+  #     TARGET_ARCH: arm64
+  #     TARGET_VARIANT: 'pointer-compression'
+  #   agents:
+  #     image: family/kibana-ubuntu-2004
+  #     provider: gcp
+  #     machineType: c2-standard-60
+  #   timeout_in_minutes: 180 # ideally runs in ~2hr
 
   - wait
 
@@ -75,12 +77,13 @@ steps:
       provider: gcp
       machineType: n2-standard-2
 
-  - label: Fix SHASUMS256.txt with newly built files' hashes with pointer compression
-    command:
-      - scripts/replace_sha_hashes.sh
-    env:
-      TARGET_VARIANT: 'pointer-compression'
-    agents:
-      image: family/kibana-ubuntu-2004
-      provider: gcp
-      machineType: n2-standard-2
+  # See https://github.com/nodejs/node/issues/54531
+  # - label: Fix SHASUMS256.txt with newly built files' hashes with pointer compression
+  #   command:
+  #     - scripts/replace_sha_hashes.sh
+  #   env:
+  #     TARGET_VARIANT: 'pointer-compression'
+  #   agents:
+  #     image: family/kibana-ubuntu-2004
+  #     provider: gcp
+  #     machineType: n2-standard-2

--- a/glibc-217/Dockerfile
+++ b/glibc-217/Dockerfile
@@ -23,10 +23,10 @@ RUN ulimit -n 1024 \
          curl \
          make \
          python2 \
-         python3 \
+         rh-python38 \
          ccache \
          xz-utils \
-         devtoolset-9 \
+         devtoolset-10 \
          glibc-devel
 
 COPY --chown=node:node entrypoint.sh /home/node/entrypoint.sh

--- a/glibc-217/entrypoint.sh
+++ b/glibc-217/entrypoint.sh
@@ -28,7 +28,8 @@ export CCACHE_DIR="/home/node/workdir/.ccache-${architecture}"
 export CC="ccache gcc"
 export CXX="ccache g++"
 
-. /opt/rh/devtoolset-9/enable
+. /opt/rh/devtoolset-10/enable
+. /opt/rh/rh-python38/enable
 
 make -j"$(getconf _NPROCESSORS_ONLN)" binary V= \
   DESTCPU="$architecture" \

--- a/pointer-compression/Dockerfile
+++ b/pointer-compression/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y \
          git \
-         g++-12 \
+         g++-13 \
          curl \
          make \
          python3 \

--- a/pointer-compression/Dockerfile
+++ b/pointer-compression/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y \
          git \
-         g++ \
+         g++-12 \
          curl \
          make \
          python3 \

--- a/pointer-compression/entrypoint.sh
+++ b/pointer-compression/entrypoint.sh
@@ -20,8 +20,8 @@ cd "/home/node/workdir/src/node-${full_version}"
 
 # Compile from source
 export CCACHE_DIR="/home/node/workdir/.ccache-${architecture}"
-export CC="ccache gcc"
-export CXX="ccache g++"
+export CC="ccache gcc-12"
+export CXX="ccache g++-12"
 
 make -j"$(getconf _NPROCESSORS_ONLN)" binary V= \
   DESTCPU="$architecture" \

--- a/pointer-compression/entrypoint.sh
+++ b/pointer-compression/entrypoint.sh
@@ -20,8 +20,8 @@ cd "/home/node/workdir/src/node-${full_version}"
 
 # Compile from source
 export CCACHE_DIR="/home/node/workdir/.ccache-${architecture}"
-export CC="ccache gcc-12"
-export CXX="ccache g++-12"
+export CC="ccache gcc-13"
+export CXX="ccache g++-13"
 
 make -j"$(getconf _NPROCESSORS_ONLN)" binary V= \
   DESTCPU="$architecture" \

--- a/scripts/upload_nodejs_artifacts.sh
+++ b/scripts/upload_nodejs_artifacts.sh
@@ -5,7 +5,7 @@ source ./scripts/common.sh
 
 # TARGET_VERSION provided in env
 
-ARTIFACT_BASE_PATH="node-$TARGET_VARIANT-test/dist/v$TARGET_VERSION/"
+ARTIFACT_BASE_PATH="node-$TARGET_VARIANT/dist/v$TARGET_VERSION/"
 ARTIFACT_DIST_DIR="./workdir/dist"
 
 list_shasums_in_folder $ARTIFACT_DIST_DIR

--- a/scripts/upload_nodejs_artifacts.sh
+++ b/scripts/upload_nodejs_artifacts.sh
@@ -5,7 +5,7 @@ source ./scripts/common.sh
 
 # TARGET_VERSION provided in env
 
-ARTIFACT_BASE_PATH="node-$TARGET_VARIANT/dist/v$TARGET_VERSION/"
+ARTIFACT_BASE_PATH="node-$TARGET_VARIANT-test/dist/v$TARGET_VERSION/"
 ARTIFACT_DIST_DIR="./workdir/dist"
 
 list_shasums_in_folder $ARTIFACT_DIST_DIR


### PR DESCRIPTION
and disables pointer-compression builds for now, they're broken on 20.latest and 22.latest.

Node 20: https://buildkite.com/elastic/kibana-custom-node-dot-js-builds/builds/210
Node 22: https://buildkite.com/elastic/kibana-custom-node-dot-js-builds/builds/209
